### PR TITLE
commenting out delete_these keys only necessary if running ./get_data.py

### DIFF
--- a/lib/render_json.py
+++ b/lib/render_json.py
@@ -41,12 +41,12 @@ def render_cases_json():
             'police_beat_id',
             'police_district',
             'police_district_id',
-            'interaction_type',
-            'officers_tags',
-            'victims_tags',
-            'misconduct_type',
-            'weapons_used',
-            'outcome'
+            #'interaction_type',
+            #'officers_tags',
+            #'victims_tags',
+            #'misconduct_type',
+            #'weapons_used',
+            #'outcome'
         ]
 
         for key in delete_these:


### PR DESCRIPTION
running lib/render_json.py and lib/render_includes.py separately obviates this change